### PR TITLE
Disable Macaroons by default

### DIFF
--- a/lightningrpc/lndRpc.go
+++ b/lightningrpc/lndRpc.go
@@ -202,14 +202,17 @@ func (lnd *LndRpc) _getClientConn(skipMacaroons bool) *grpc.ClientConn {
 			log.Errorf("%v", err)
 		}
 
-		macConstraints := []macaroons.Constraint{
-			macaroons.TimeoutConstraint(lnd.macaroonTimeout),
+		var macConstraints []macaroons.Constraint
 
-			// Lock macaroon down to a specific IP address.
-			macaroons.IPLockConstraint(lnd.macaroonIp),
-
-			// ... Add more constraints if needed.
+		// Optionally add timeout.
+		if lnd.macaroonTimeout > 0 {
+			macConstraints = append(macConstraints,
+				macaroons.TimeoutConstraint(lnd.macaroonTimeout))
 		}
+
+		// Lock macaroon down to a specific IP address.
+		macConstraints = append(macConstraints, macaroons.IPLockConstraint(lnd.macaroonIp))
+		// ... Add more constraints if needed.
 
 		// Apply constraints to the macaroon.
 		constrainedMac, err := macaroons.AddConstraints(mac, macConstraints...)

--- a/lseed.go
+++ b/lseed.go
@@ -19,7 +19,7 @@ var (
 
 	listenAddr   = flag.String("listen", "0.0.0.0:53", "Listen address for incoming requests.")
 	rootDomain   = flag.String("root-domain", "lseed.bitcoinstats.com", "Root DNS seed domain.")
-	pollInterval = flag.Int("poll-interval", 10, "Time between polls to lightningd for updates")
+	pollInterval = flag.Int("poll-interval", 10, "Time between polls to lightningd for updates in second.")
 	debug        = flag.Bool("debug", false, "Be very verbose")
 	numResults   = flag.Int("results", 25, "How many results shall we return to a query?")
 

--- a/lseed.go
+++ b/lseed.go
@@ -35,7 +35,7 @@ var (
 	lndTlsCertPath     = flag.String("tlscertpath", "~/.lnd/tls.cert", "Path to TLS certificate")
 	lndNoMacaroons     = flag.Bool("no-macaroons", false, "Skip Macaroon authetication for lnd")
 	lndMacaroonPath    = flag.String("macaroonpath", "~/.lnd/admin.macaroon", "Path to macaroon file")
-	lndMacaroonTimeout = flag.Int64("macaroontimeout", 60, "Anti-replay macaroon validity time in seconds")
+	lndMacaroonTimeout = flag.Int64("macaroontimeout", 0, "Anti-replay macaroon validity time in seconds")
 	lndMacaroonIp      = flag.String("macaroonip", "", "If set, lock macaroon to specific IP address")
 )
 


### PR DESCRIPTION
Unlike `lncli`, `lseed` queries `lnd` periodically. There's no reason to set a timeout on the connection session.